### PR TITLE
chore: add Google Search Console verification meta tag

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -52,6 +52,9 @@ export const metadata: Metadata = {
   // screen). favicon.ico is kept as-is: it already works, no reason to
   // replace it with a generated equivalent.
   icons: { icon: "/favicon.ico", apple: "/apple-icon" },
+  verification: {
+    google: "YF_pXgxB-6KdItwpFEQPtU_CFXo1sGSWH-Y9qL4QeM8",
+  },
 };
 
 export default function RootLayout({


### PR DESCRIPTION
Adds the Google Search Console ownership-verification meta tag via Next.js's built-in `verification.google` metadata field, confirmed rendering correctly in the built homepage HTML.