### PR TITLE
feat: UI overhaul — typography, motion hierarchy, design tokens

### DIFF
--- a/app/components/GroqChatbot/Chatbot.tsx
+++ b/app/components/GroqChatbot/Chatbot.tsx
@@ -135,7 +135,7 @@ export default function Chatbot() {
           >
             <div className="flex items-center justify-between border-b border-black/10 bg-[#61DCA3] px-4 py-3 text-black ">
               <div>
-                <h3 className="text-sm font-bold">Akhyar&apos;s Assistant</h3>
+                <h3 className="text-sm font-semibold">Akhyar&apos;s Assistant</h3>
                 <p className="text-xs font-medium text-black/70">
                   Projects, skills, and experience
                 </p>

--- a/app/components/ScrollVelocity/ScrollVelocity.tsx
+++ b/app/components/ScrollVelocity/ScrollVelocity.tsx
@@ -123,7 +123,7 @@ function VelocityText({
       style={parallaxStyle}
     >
       <motion.div
-        className={`${scrollerClassName} flex whitespace-nowrap text-center font-sans text-4xl font-bold tracking-[-0.02em] drop-shadow md:text-[5rem] md:leading-[3rem]`}
+        className={`${scrollerClassName} flex whitespace-nowrap text-center font-sans text-4xl font-semibold tracking-[-0.02em] drop-shadow md:text-[5rem] md:leading-[3rem]`}
         style={{ x, ...scrollerStyle }}
       >
         {Array.from({ length: numCopies }, (_, index) => (

--- a/app/components/Squares/Squares.tsx
+++ b/app/components/Squares/Squares.tsx
@@ -28,6 +28,7 @@ const Squares: React.FC<SquaresProps> = ({
   const numSquaresY = useRef<number>(0);
   const gridOffset = useRef<GridOffset>({ x: 0, y: 0 });
   const hoveredSquareRef = useRef<GridOffset | null>(null);
+  const frameCount = useRef(0);
 
   useEffect(() => {
     const canvas = canvasRef.current;
@@ -101,7 +102,16 @@ const Squares: React.FC<SquaresProps> = ({
         return;
       }
 
-      const effectiveSpeed = Math.max(speed, 0.1);
+      frameCount.current += 1;
+      if (frameCount.current % 3 !== 0) {
+        requestRef.current = requestAnimationFrame(updateAnimation);
+        return;
+      }
+
+      // Multiplied by 3 to compensate for only running every 3rd frame —
+      // the grid still moves at the same on-screen speed as before,
+      // drawGrid() just runs a third as often.
+      const effectiveSpeed = Math.max(speed, 0.1) * 3;
       switch (direction) {
         case "right":
           gridOffset.current.x =

--- a/app/components/layout/Footer.tsx
+++ b/app/components/layout/Footer.tsx
@@ -2,6 +2,7 @@
 
 import { motion, useReducedMotion } from "framer-motion";
 import { FaEnvelope, FaGithub, FaInstagram, FaLinkedin } from "react-icons/fa";
+import { easeMajor } from "@/lib/motion";
 
 const SOCIALS = [
   { href: "https://github.com/Akhyarrrrr", Icon: FaGithub, label: "GitHub" },
@@ -21,7 +22,7 @@ export default function Footer() {
         initial={reduceMotion ? false : { opacity: 0, y: 18 }}
         whileInView={{ opacity: 1, y: 0 }}
         viewport={{ once: true, amount: 0.5 }}
-        transition={{ duration: 0.45, ease: [0.16, 1, 0.3, 1] }}
+        transition={{ duration: 0.45, ease: easeMajor }}
       >
         <div className="flex items-center gap-3">
           <span className="text-2xl font-extrabold tracking-tight text-white">Y.</span>

--- a/app/components/layout/Navbar.tsx
+++ b/app/components/layout/Navbar.tsx
@@ -243,7 +243,7 @@ function LangItem({
       <div className="flex items-center gap-3">
         <span
           className="inline-flex h-6 w-6 items-center justify-center rounded-md
-                         border border-white/15 bg-white/5 text-[10px] font-bold"
+                         border border-white/15 bg-white/5 text-[10px] font-semibold"
         >
           {code}
         </span>

--- a/app/components/sections/About.tsx
+++ b/app/components/sections/About.tsx
@@ -1,9 +1,10 @@
 "use client";
 
 import { useEffect, useRef, useState } from "react";
-import { motion, useInView, type Variants } from "framer-motion";
+import { motion, useInView, useReducedMotion, type Variants } from "framer-motion";
 import { Briefcase, Code2, Users, Zap } from "lucide-react";
 import { useLanguage } from "@/context/LanguageProvider";
+import { fadeUpMajor, fadeMicro } from "@/lib/motion";
 
 /* ─── i18n data ─────────────────────────────────────────────── */
 const aboutData = {
@@ -19,7 +20,7 @@ const aboutData = {
       { icon: Briefcase,title: "Production Ownership",    desc: "Hold full server access for a platform running 90+ academic journals, with hands-on experience in incident response, backups, monitoring, and zero-downtime migrations." },
     ],
     stats: [
-      { label: "Projects Shipped",     value: 10, suffix: "+" },
+      { label: "Projects Shipped",     value: 15, suffix: "+" },
       { label: "Journals in Production",value: 90, suffix: "+" },
       { label: "Zero-Downtime Migrations Led",value: 1, suffix: "" },
     ],
@@ -76,45 +77,51 @@ function Counter({ target, suffix }: { target: number; suffix: string }) {
 }
 
 /* ─── Framer variants ───────────────────────────────────────── */
+// Container still staggers its children's *entrance timing* — only the
+// per-child motion itself (now fadeMicro) got quieter.
 const container: Variants = {
   hidden: { opacity: 0 },
   visible: { opacity: 1, transition: { staggerChildren: 0.09, delayChildren: 0.1 } },
-};
-const item: Variants = {
-  hidden:   { opacity: 0, y: 24 },
-  visible:  { opacity: 1, y: 0, transition: { duration: 0.5 } },
 };
 
 /* ─── Component ─────────────────────────────────────────────── */
 export default function About() {
   const { lang } = useLanguage();
   const data = aboutData[lang];
+  const reduceMotion = useReducedMotion();
 
   return (
     <section
       id="about"
       className="relative z-10 w-full bg-[#0B0F15] px-4 py-24 sm:px-6"
     >
-      <motion.div
-        className="mx-auto max-w-6xl"
-        initial="hidden"
-        whileInView="visible"
-        viewport={{ once: true, margin: "-80px" }}
-        variants={container}
-      >
+      <div className="mx-auto max-w-6xl">
         {/* Heading */}
-        <motion.div className="mb-16 text-center" variants={item}>
+        <motion.div
+          className="mb-16 text-center"
+          initial={reduceMotion ? false : "hidden"}
+          whileInView="visible"
+          viewport={{ once: true, margin: "-80px" }}
+          variants={fadeUpMajor}
+        >
           <div className="inline-flex items-center gap-2 rounded-full border border-[#61DCA3]/30 bg-[#61DCA3]/10 px-4 py-1.5 mb-4">
             <span className="w-1.5 h-1.5 rounded-full bg-[#61DCA3]" />
             <span className="text-xs text-[#61DCA3] font-medium uppercase tracking-widest">{data.badge}</span>
           </div>
-          <h2 className="text-4xl font-extrabold text-white tracking-tight">
+          <h2 className="font-accent text-4xl font-medium text-white tracking-tight">
             {data.heading}
           </h2>
           <p className="mt-4 text-white/50 max-w-xl mx-auto text-sm leading-relaxed">
             {data.intro}{" "}{data.mission}
           </p>
         </motion.div>
+
+        <motion.div
+          initial={reduceMotion ? false : "hidden"}
+          whileInView="visible"
+          viewport={{ once: true, margin: "-80px" }}
+          variants={container}
+        >
 
         {/* Highlight cards */}
         <motion.div className="mb-16 grid gap-5 md:grid-cols-2" variants={container}>
@@ -124,10 +131,11 @@ export default function About() {
               <motion.div
                 key={highlight.title}
                 className="group rounded-2xl border border-white/8 bg-white/[0.03]
-                           p-6 transition-all duration-300
+                           p-6 shadow-[0_4px_16px_rgba(0,0,0,0.15)]
+                           transition-all duration-300
                            hover:border-[#61DCA3]/40 hover:bg-[#61DCA3]/5
-                           hover:shadow-[0_0_30px_rgba(97,220,163,0.06)]"
-                variants={item}
+                           hover:shadow-[0_12px_36px_rgba(97,220,163,0.1)]"
+                variants={fadeMicro}
                 whileHover={{ y: -4 }}
               >
                 <div className="mb-4 inline-flex h-10 w-10 items-center justify-center
@@ -154,7 +162,7 @@ export default function About() {
               className={`flex flex-col items-center justify-center py-8 px-4
                           bg-white/[0.02] hover:bg-[#61DCA3]/5 transition-colors duration-300
                           ${i < data.stats.length - 1 ? "border-r border-white/8 last:border-r-0" : ""}`}
-              variants={item}
+              variants={fadeMicro}
             >
               <div className="text-3xl md:text-4xl font-extrabold text-[#61DCA3] tabular-nums">
                 <Counter target={stat.value} suffix={stat.suffix} />
@@ -165,7 +173,7 @@ export default function About() {
         </motion.div>
 
         {/* CTA */}
-        <motion.div className="text-center" variants={item}>
+        <motion.div className="text-center" variants={fadeMicro}>
           <p className="mb-6 text-white/50 text-sm">{data.cta}</p>
           <a
             href="#contact"
@@ -179,7 +187,8 @@ export default function About() {
             {data.ctaBtn}
           </a>
         </motion.div>
-      </motion.div>
+        </motion.div>
+      </div>
     </section>
   );
 }

--- a/app/components/sections/Contact.tsx
+++ b/app/components/sections/Contact.tsx
@@ -6,21 +6,10 @@ import {
   AnimatePresence,
   motion,
   useReducedMotion,
-  type Variants,
 } from "framer-motion";
 import { AlertCircle, CheckCircle, Send } from "lucide-react";
 import { useLanguage } from "@/context/LanguageProvider";
-
-const easeOut = [0.16, 1, 0.3, 1] as const;
-
-const fadeUp: Variants = {
-  hidden: { opacity: 0, y: 32 },
-  visible: {
-    opacity: 1,
-    y: 0,
-    transition: { duration: 0.55, ease: easeOut },
-  },
-};
+import { fadeUpMajor } from "@/lib/motion";
 
 function Field({
   id,
@@ -96,9 +85,9 @@ export default function Contact() {
           initial={reduceMotion ? false : "hidden"}
           whileInView="visible"
           viewport={{ once: true, amount: 0.42 }}
-          variants={fadeUp}
+          variants={fadeUpMajor}
         >
-          <h2 className="text-4xl font-extrabold tracking-tight text-white">
+          <h2 className="font-accent text-4xl font-medium tracking-tight text-white">
             {t("contact.heading")}
           </h2>
           <p className="mx-auto mt-3 max-w-md text-sm leading-relaxed text-white/45">
@@ -111,7 +100,7 @@ export default function Contact() {
           initial={reduceMotion ? false : "hidden"}
           whileInView="visible"
           viewport={{ once: true, amount: 0.2 }}
-          variants={fadeUp}
+          variants={fadeUpMajor}
         >
           <div className="grid items-center gap-10 md:grid-cols-[0.8fr_1.2fr]">
             <div className="flex justify-center">

--- a/app/components/sections/Experience.tsx
+++ b/app/components/sections/Experience.tsx
@@ -45,7 +45,7 @@ function getLastYear(year: string) {
 function Logo({ exp }: { exp: ExperienceType }) {
   if (!exp.logo) {
     return (
-      <div className="flex h-12 w-12 items-center justify-center rounded-full border-2 border-[#61DCA3]/40 bg-[#61DCA3]/10 text-sm font-bold text-[#61DCA3]">
+      <div className="flex h-12 w-12 items-center justify-center rounded-full border-2 border-[#61DCA3]/40 bg-[#61DCA3]/10 text-sm font-semibold text-[#61DCA3]">
         {exp.company?.charAt(0) ?? "?"}
       </div>
     );
@@ -158,7 +158,7 @@ export default function Experience({
 
                 <div className={`flex flex-col gap-3 ${infoClass}`}>
                   <div>
-                    <h3 className="text-xl font-bold leading-tight text-white">
+                    <h3 className="text-xl font-semibold leading-tight text-white">
                       {exp.title}
                     </h3>
                     <p className="mt-1 text-sm font-medium text-[#61DCA3]">

--- a/app/components/sections/Experience.tsx
+++ b/app/components/sections/Experience.tsx
@@ -12,27 +12,15 @@ import {
 } from "framer-motion";
 import { type ExperienceType } from "@/lib/content";
 import { RichText, useLanguage } from "@/context/LanguageProvider";
-
-const easeOut = [0.16, 1, 0.3, 1] as const;
-
-const headingVariants: Variants = {
-  hidden: { opacity: 0, y: 28 },
-  visible: {
-    opacity: 1,
-    y: 0,
-    transition: { duration: 0.55, ease: easeOut },
-  },
-};
+import { fadeUpMajor } from "@/lib/motion";
 
 const rowVariants: Variants = {
-  hidden: { opacity: 0, y: 34 },
+  hidden: { opacity: 0 },
   visible: (index = 0) => ({
     opacity: 1,
-    y: 0,
     transition: {
-      duration: 0.55,
+      duration: 0.2,
       delay: Math.min(index * 0.08, 0.32),
-      ease: easeOut,
     },
   }),
 };
@@ -103,7 +91,7 @@ export default function Experience({
         initial={reduceMotion ? false : "hidden"}
         whileInView="visible"
         viewport={{ once: true, amount: 0.45 }}
-        variants={headingVariants}
+        variants={fadeUpMajor}
       >
         <div className="mb-4 inline-flex items-center gap-2 rounded-full border border-[#61DCA3]/30 bg-[#61DCA3]/10 px-4 py-1.5">
           <span className="h-1.5 w-1.5 rounded-full bg-[#61DCA3]" />
@@ -111,7 +99,7 @@ export default function Experience({
             {badge}
           </span>
         </div>
-        <h2 className="text-4xl font-extrabold tracking-tight text-white [&_span]:text-[#61DCA3]">
+        <h2 className="font-accent text-4xl font-medium tracking-tight text-white [&_span]:text-[#61DCA3]">
           <RichText i18nKey="experience.heading" />
         </h2>
         <p className="mx-auto mt-4 max-w-xl text-sm leading-relaxed text-white/50">
@@ -172,7 +160,7 @@ export default function Experience({
                 </div>
 
                 <p
-                  className={`max-w-md rounded-xl border border-white/8 bg-white/[0.03] p-5 text-sm leading-relaxed text-white/60 transition-colors duration-300 hover:border-[#61DCA3]/25 hover:bg-[#61DCA3]/5 ${descClass}`}
+                  className={`max-w-md rounded-xl border border-white/8 bg-white/[0.03] p-5 shadow-[0_4px_16px_rgba(0,0,0,0.12)] text-sm leading-relaxed text-white/60 transition-all duration-300 hover:-translate-y-1 hover:border-[#61DCA3]/25 hover:bg-[#61DCA3]/5 hover:shadow-[0_12px_32px_rgba(97,220,163,0.08)] ${descClass}`}
                 >
                   {exp.description}
                 </p>

--- a/app/components/sections/Hero.tsx
+++ b/app/components/sections/Hero.tsx
@@ -5,6 +5,7 @@ import { FaGithub, FaInstagram, FaLinkedin } from "react-icons/fa";
 import { HiDownload } from "react-icons/hi";
 import { useLanguage } from "@/context/LanguageProvider";
 import { motion, useReducedMotion } from "framer-motion";
+import { easeMajor } from "@/lib/motion";
 
 const Lanyard = dynamic(() => import("../Lanyard/Lanyard"), {
   ssr: false,
@@ -85,7 +86,7 @@ export default function Hero() {
               <motion.p
                 initial={reduceMotion ? false : { opacity: 0, x: 32 }}
                 animate={{ opacity: 1, x: 0 }}
-                transition={{ duration: 0.55, ease: [0.16, 1, 0.3, 1] }}
+                transition={{ duration: 0.55, ease: easeMajor }}
                 className="max-w-fit border-l border-[#61DCA3]/60 pl-3 text-xs font-semibold text-[#61DCA3] sm:text-sm"
               >
                 {t("hero.welcome")}
@@ -95,7 +96,7 @@ export default function Hero() {
                 key={`hero-title-${lang}`}
                 initial={reduceMotion ? false : { opacity: 0, y: 36 }}
                 animate={{ opacity: 1, y: 0 }}
-                transition={{ delay: 0.12, duration: 0.7, ease: [0.16, 1, 0.3, 1] }}
+                transition={{ delay: 0.12, duration: 0.7, ease: easeMajor }}
                 className="flex flex-col items-start gap-1 text-white"
               >
                 <span
@@ -106,7 +107,7 @@ export default function Hero() {
                 </span>
                 <span
                   key={`name-${lang}`}
-                  className="text-5xl md:text-7xl font-extrabold text-start text-[#61DCA3] leading-tight"
+                  className="font-accent text-5xl md:text-7xl font-medium italic text-start text-[#61DCA3] leading-tight"
                 >
                   {t("hero.name")}
                 </span>
@@ -116,7 +117,7 @@ export default function Hero() {
                 key={`hero-tagline-${lang}`}
                 initial={reduceMotion ? false : { opacity: 0, y: 18 }}
                 animate={{ opacity: 1, y: 0 }}
-                transition={{ delay: 0.22, duration: 0.6, ease: [0.16, 1, 0.3, 1] }}
+                transition={{ delay: 0.22, duration: 0.6, ease: easeMajor }}
                 className="text-base md:text-lg text-white/70 max-w-md leading-relaxed"
               >
                 {t("hero.tagline")}

--- a/app/components/sections/Hero.tsx
+++ b/app/components/sections/Hero.tsx
@@ -187,7 +187,7 @@ export default function Hero() {
             <motion.div
               initial={reduceMotion ? false : { opacity: 0, scale: 0.96, y: 28 }}
               animate={{ opacity: 1, scale: 1, y: 0 }}
-              transition={{ delay: 0.25, duration: 0.7, ease: [0.16, 1, 0.3, 1] }}
+              transition={{ delay: 0.25, duration: 0.7, ease: easeMajor }}
               className="max-lg:relative max-lg:-mt-24 max-lg:h-[530px] max-lg:w-full max-lg:max-w-[470px] max-lg:overflow-hidden max-lg:pt-22 max-lg:sm:-mt-28 max-lg:sm:h-[620px] max-lg:sm:max-w-[560px] max-lg:sm:pt-20 max-lg:md:-mt-24 max-lg:md:h-[700px] max-lg:md:max-w-[660px] max-lg:md:pt-24 lg:h-full lg:w-full"
             >
               {shouldMountLanyard ? (

--- a/app/components/sections/Hero.tsx
+++ b/app/components/sections/Hero.tsx
@@ -100,7 +100,7 @@ export default function Hero() {
               >
                 <span
                   key={`hey-${lang}`}
-                  className="text-4xl md:text-6xl font-bold text-start leading-tight"
+                  className="text-4xl md:text-6xl font-semibold text-start leading-tight"
                 >
                   {t("hero.hey")}
                 </span>

--- a/app/components/sections/Project.tsx
+++ b/app/components/sections/Project.tsx
@@ -6,6 +6,7 @@ import { motion, useReducedMotion, type Variants } from "framer-motion";
 import { ExternalLink, GithubIcon, Pin } from "lucide-react";
 import { useLanguage, RichText } from "@/context/LanguageProvider";
 import type { ProjectType } from "@/lib/content";
+import { fadeUpMajor, fadeMicro } from "@/lib/motion";
 import {
   getFallbackTechIcon,
   getTechDisplayLabel,
@@ -31,11 +32,6 @@ const SkeletonCard = () => (
   </div>
 );
 
-const fadeUp: Variants = {
-  hidden: { opacity: 0, y: 28 },
-  visible: { opacity: 1, y: 0, transition: { duration: 0.5 } },
-};
-
 const projectGrid: Variants = {
   hidden: { opacity: 0 },
   visible: {
@@ -44,16 +40,6 @@ const projectGrid: Variants = {
       delayChildren: 0.12,
       staggerChildren: 0.08,
     },
-  },
-};
-
-const projectCard: Variants = {
-  hidden: { opacity: 0, y: 28, scale: 0.98 },
-  visible: {
-    opacity: 1,
-    y: 0,
-    scale: 1,
-    transition: { duration: 0.45, ease: "easeOut" },
   },
 };
 
@@ -187,7 +173,7 @@ export default function Project({
           initial={reduceMotion ? false : "hidden"}
           whileInView="visible"
           viewport={{ once: true, margin: "-60px" }}
-          variants={fadeUp}
+          variants={fadeUpMajor}
         >
           <div className="mb-4 inline-flex items-center gap-2 rounded-full border border-[#61DCA3]/30 bg-[#61DCA3]/10 px-4 py-1.5">
             <span className="h-1.5 w-1.5 rounded-full bg-[#61DCA3]" />
@@ -195,7 +181,7 @@ export default function Project({
               {lang === "id" ? "Karya Saya" : "My Work"}
             </span>
           </div>
-          <h2 className="text-4xl font-extrabold tracking-tight text-white [&_span]:text-[#61DCA3]">
+          <h2 className="font-accent text-4xl font-medium tracking-tight text-white [&_span]:text-[#61DCA3]">
             <RichText i18nKey="project.heading" />
           </h2>
           <p className="mx-auto mt-3 max-w-xl text-sm text-white/40">
@@ -247,7 +233,7 @@ export default function Project({
             Array.from({ length: itemsPerPage }).map((_, index) => (
               <motion.div
                 key={index}
-                variants={projectCard}
+                variants={fadeMicro}
                 className="flex h-[24rem] w-96 max-w-full items-center justify-center"
               >
                 <SkeletonCard />
@@ -296,7 +282,7 @@ export default function Project({
               return (
                 <motion.div
                   key={project.id}
-                  variants={projectCard}
+                  variants={fadeMicro}
                   className="flex justify-center"
                 >
                   <div className="group/card block h-[24rem] w-96 max-w-full [perspective:1000px]">

--- a/app/components/sections/Project.tsx
+++ b/app/components/sections/Project.tsx
@@ -335,7 +335,7 @@ export default function Project({
                           )}
                         </div>
 
-                        <h3 className="mt-6 mb-1.5 line-clamp-1 text-base font-bold leading-6 text-slate-100">
+                        <h3 className="mt-6 mb-1.5 line-clamp-1 text-base font-semibold leading-6 text-slate-100">
                           {title}
                         </h3>
                         <p className="mb-3 line-clamp-2 text-xs leading-5 text-slate-500">

--- a/app/components/sections/Skills.tsx
+++ b/app/components/sections/Skills.tsx
@@ -15,7 +15,7 @@ function SkillBadge({ name, icon }: { name: string; icon: React.ReactNode }) {
     >
       <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-[#61DCA3]/10 border border-[#61DCA3]/15 transition-colors group-hover:bg-[#61DCA3]/20">
         {icon ?? (
-          <span className="text-[10px] font-bold text-[#61DCA3]">
+          <span className="text-[10px] font-semibold text-[#61DCA3]">
             {name[0]}
           </span>
         )}

--- a/app/components/sections/Skills.tsx
+++ b/app/components/sections/Skills.tsx
@@ -1,9 +1,10 @@
 "use client";
 
-import { motion, type Variants } from "framer-motion";
+import { motion, useReducedMotion } from "framer-motion";
 import ScrollVelocity from "../ScrollVelocity/ScrollVelocity";
 import { getTechsByCategory } from "@/lib/tech-stack";
 import { RichText, useLanguage } from "@/context/LanguageProvider";
+import { fadeUpMajor } from "@/lib/motion";
 
 function SkillBadge({ name, icon }: { name: string; icon: React.ReactNode }) {
   return (
@@ -29,13 +30,9 @@ function SkillBadge({ name, icon }: { name: string; icon: React.ReactNode }) {
 
 const categoryList = getTechsByCategory();
 
-const fadeUp: Variants = {
-  hidden: { opacity: 0, y: 24 },
-  visible: { opacity: 1, y: 0, transition: { duration: 0.5 } },
-};
-
 export default function SkillsTape() {
   const { t } = useLanguage();
+  const reduceMotion = useReducedMotion();
   return (
     <section
       className="relative z-10 bg-[#0B0F15] pt-28 overflow-hidden"
@@ -43,10 +40,10 @@ export default function SkillsTape() {
     >
       <div className="mx-auto mb-14 max-w-5xl px-4 sm:px-6 text-center">
         <motion.div
-          initial="hidden"
+          initial={reduceMotion ? false : "hidden"}
           whileInView="visible"
           viewport={{ once: true, margin: "-60px" }}
-          variants={fadeUp}
+          variants={fadeUpMajor}
         >
           <div className="mb-4 inline-flex items-center gap-2 rounded-full border border-[#61DCA3]/30 bg-[#61DCA3]/10 px-4 py-1.5">
             <span className="h-1.5 w-1.5 rounded-full bg-[#61DCA3]" />
@@ -54,7 +51,7 @@ export default function SkillsTape() {
               {t("skills.badge")}
             </span>
           </div>
-          <h2 className="text-4xl font-extrabold tracking-tight text-[#61DCA3]">
+          <h2 className="font-accent text-4xl font-medium tracking-tight text-[#61DCA3]">
             <RichText i18nKey="skills.heading" />
           </h2>
           <p className="mx-auto mt-3 max-w-md text-sm text-white/40">

--- a/app/error.tsx
+++ b/app/error.tsx
@@ -20,7 +20,7 @@ export default function Error({
           <span className="text-2xl">!</span>
         </div>
       </div>
-      <h1 className="text-2xl font-bold text-white">Something went wrong</h1>
+      <h1 className="text-2xl font-semibold text-white">Something went wrong</h1>
       <p className="max-w-md text-sm text-white/40">
         An unexpected error occurred. Please try again.
       </p>

--- a/app/globals.css
+++ b/app/globals.css
@@ -4,10 +4,27 @@
   --color-dark: #0B0F15;
   --color-accent: #61DCA3;
   --color-accent-hover: #4ecf96;
+  /* Warm variant for serif/personal moments (hero name, section headings,
+     pull quotes) — same hue family as --color-accent, shifted from 152°
+     (mint) toward 100° (yellow-green) so it reads as warmer without
+     leaving "green." Never used in functional UI; see the font-family
+     rule below for the matching typography constraint. */
+  --color-accent-warm: #8ED96B;
   --color-surface: rgba(255, 255, 255, 0.03);
   --color-border: rgba(255, 255, 255, 0.08);
   --font-family-sans: "Poppins", sans-serif;
+  --font-family-accent: "Fraunces", serif;
 }
+
+/* Radius convention (Tailwind's default scale already matches the spec's
+   8/12/16/24px scale — rounded-lg/xl/2xl/3xl respectively — so no new
+   radius tokens are needed, just a rule for which gets which):
+     rounded-lg  (8px)  — small inline controls: badges, pills, tags
+     rounded-xl  (12px) — buttons, inputs, small interactive surfaces
+     rounded-2xl (16px) — cards, panels
+     rounded-3xl (24px) — large hero containers, modals
+   Spacing convention: Tailwind's default scale (1=4px..24=96px) already
+   matches the spec's scale — use it directly, no arbitrary px values. */
 
 html {
   position: relative;

--- a/app/globals.css
+++ b/app/globals.css
@@ -26,6 +26,13 @@
    Spacing convention: Tailwind's default scale (1=4px..24=96px) already
    matches the spec's scale — use it directly, no arbitrary px values. */
 
+/* Serif accent utility — hero name, section headings, pull quotes ONLY.
+   Never apply to nav links, badges, buttons, or form labels (grep for
+   this class during review; every match must be one of those three). */
+.font-accent {
+  font-family: var(--font-fraunces), var(--font-family-accent), serif;
+}
+
 html {
   position: relative;
   scroll-behavior: smooth;

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -7,9 +7,9 @@ const SITE_URL = "https://akhyar.dev";
 
 const poppins = Poppins({
   subsets: ["latin"],
-  // Cut from 6 weights to 3 — fewer weights forces every remaining one
+  // Cut from 6 weights to 4 — fewer weights forces every remaining one
   // to carry real hierarchy meaning instead of being interchangeable.
-  weight: ["400", "600", "800"],
+  weight: ["400", "500", "600", "800"],
   variable: "--font-poppins",
   display: "swap",
 });

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,5 +1,5 @@
 import type { Metadata, Viewport } from "next";
-import { Poppins } from "next/font/google";
+import { Fraunces, Poppins } from "next/font/google";
 import "./globals.css";
 import { LanguageProvider } from "@/context/LanguageProvider";
 
@@ -7,8 +7,22 @@ const SITE_URL = "https://akhyar.dev";
 
 const poppins = Poppins({
   subsets: ["latin"],
-  weight: ["300", "400", "500", "600", "700", "800"],
+  // Cut from 6 weights to 3 — fewer weights forces every remaining one
+  // to carry real hierarchy meaning instead of being interchangeable.
+  weight: ["400", "600", "800"],
   variable: "--font-poppins",
+  display: "swap",
+});
+
+// Serif accent — hero name, section headings, pull quotes only (never
+// nav links, badges, buttons, or form labels; see Global Constraints).
+// Fraunces' optical-size axis keeps it warm and characterful at large
+// hero sizes without going illegible at smaller heading sizes.
+const fraunces = Fraunces({
+  subsets: ["latin"],
+  weight: ["500", "600"],
+  style: ["normal", "italic"],
+  variable: "--font-fraunces",
   display: "swap",
 });
 
@@ -62,7 +76,7 @@ export default function RootLayout({
 }: Readonly<{ children: React.ReactNode }>) {
   return (
     <html lang="en" className="scroll-smooth">
-      <body className={`${poppins.variable} font-sans antialiased`}>
+      <body className={`${poppins.variable} ${fraunces.variable} font-sans antialiased`}>
         <a
           href="#main-content"
           className="sr-only focus:not-sr-only focus:fixed focus:top-4 focus:left-4 focus:z-[9999] focus:rounded-xl focus:bg-[#61DCA3] focus:px-4 focus:py-2 focus:text-sm focus:font-semibold focus:text-black focus:shadow-lg"

--- a/app/not-found.tsx
+++ b/app/not-found.tsx
@@ -6,7 +6,7 @@ export default function NotFound() {
       <p className="text-8xl font-extrabold tracking-tight text-[#61DCA3]/20">
         404
       </p>
-      <h1 className="text-2xl font-bold text-white">Page not found</h1>
+      <h1 className="text-2xl font-semibold text-white">Page not found</h1>
       <p className="max-w-md text-sm text-white/40">
         The page you&apos;re looking for doesn&apos;t exist or has been moved.
       </p>

--- a/app/projects/[slug]/ProjectDetailClient.tsx
+++ b/app/projects/[slug]/ProjectDetailClient.tsx
@@ -421,7 +421,7 @@ export default function ProjectDetailClient({
                         className="object-cover"
                       />
                     </div>
-                    <h3 className="mb-1 text-base font-bold text-white group-hover:text-[#61DCA3] transition-colors">
+                    <h3 className="mb-1 text-base font-semibold text-white group-hover:text-[#61DCA3] transition-colors">
                       {titleLocal(rp, lang)}
                     </h3>
                     <div className="flex items-center gap-1 text-xs text-white/40">

--- a/app/projects/[slug]/ProjectDetailClient.tsx
+++ b/app/projects/[slug]/ProjectDetailClient.tsx
@@ -16,6 +16,7 @@ import Image from "next/image";
 import Link from "next/link";
 import { useLanguage } from "@/context/LanguageProvider";
 import type { ProjectType } from "@/lib/content";
+import { fadeUpMajor, fadeMicro } from "@/lib/motion";
 import {
   getTechDisplayLabel,
   getTechMeta,
@@ -23,11 +24,6 @@ import {
 } from "@/lib/tech-stack";
 
 // ── helpers ───────────────────────────────────────────────────
-
-const fadeUp: Variants = {
-  hidden: { opacity: 0, y: 32 },
-  visible: { opacity: 1, y: 0, transition: { duration: 0.55 } },
-};
 
 const fadeUpStagger: Variants = {
   hidden: { opacity: 0 },
@@ -93,14 +89,14 @@ function CaseStudySection({
       initial={reduceMotion ? false : "hidden"}
       whileInView="visible"
       viewport={{ once: true, margin: "-60px" }}
-      variants={fadeUp}
+      variants={fadeUpMajor}
       className={`mb-16 ${className}`}
     >
       <div className="flex items-start gap-4">
         {/* Left accent bar */}
         <div className="mt-1.5 h-6 w-1 shrink-0 rounded-full bg-gradient-to-b from-[#61DCA3] to-[#3dd68c]" />
         <div>
-          <h2 className="mb-4 text-2xl font-extrabold text-white tracking-tight md:text-3xl">
+          <h2 className="font-accent mb-4 text-2xl font-medium text-white tracking-tight md:text-3xl">
             {title}
           </h2>
           <div className="text-base leading-relaxed text-white/60">{children}</div>
@@ -199,7 +195,7 @@ export default function ProjectDetailClient({
           className="mb-16"
         >
           {/* Badge row */}
-          <motion.div variants={fadeUp} className="mb-4 flex flex-wrap items-center gap-3">
+          <motion.div variants={fadeUpMajor} className="mb-4 flex flex-wrap items-center gap-3">
             <span className="inline-flex items-center gap-1.5 rounded-full border border-[#61DCA3]/30 bg-[#61DCA3]/10 px-3 py-1 text-xs font-medium text-[#61DCA3]">
               {project.category === "mobile" ? (
                 <>
@@ -222,15 +218,15 @@ export default function ProjectDetailClient({
 
           {/* Title */}
           <motion.h1
-            variants={fadeUp}
-            className="mb-4 text-4xl font-extrabold tracking-tight text-white md:text-5xl"
+            variants={fadeUpMajor}
+            className="font-accent mb-4 text-4xl font-medium tracking-tight text-white md:text-5xl"
           >
             {titleLocal(project, lang)}
           </motion.h1>
 
           {/* Meta row */}
           <motion.div
-            variants={fadeUp}
+            variants={fadeUpMajor}
             className="mb-5 flex flex-wrap items-center gap-4 text-sm text-white/40"
           >
             {project.year && (
@@ -251,12 +247,12 @@ export default function ProjectDetailClient({
           </motion.div>
 
           {/* Tagline / short desc */}
-          <motion.p variants={fadeUp} className="mb-6 max-w-2xl text-lg leading-relaxed text-white/60">
+          <motion.p variants={fadeUpMajor} className="mb-6 max-w-2xl text-lg leading-relaxed text-white/60">
             {descLocal(project, lang)}
           </motion.p>
 
           {/* CTA buttons */}
-          <motion.div variants={fadeUp} className="mb-8 flex flex-wrap gap-3">
+          <motion.div variants={fadeUpMajor} className="mb-8 flex flex-wrap gap-3">
             {href && (
               <a
                 href={href}
@@ -280,14 +276,14 @@ export default function ProjectDetailClient({
           </motion.div>
 
           {/* Tech badges */}
-          <motion.div variants={fadeUp} className="mb-8 flex flex-wrap gap-2">
+          <motion.div variants={fadeUpMajor} className="mb-8 flex flex-wrap gap-2">
             {techList.map((tech, i) => (
               <TechBadge key={`${project.id}-hero-t-${i}`} tech={tech} />
             ))}
           </motion.div>
 
           {/* Hero image */}
-          <motion.div variants={fadeUp}>
+          <motion.div variants={fadeUpMajor}>
             <div className="relative aspect-video overflow-hidden rounded-2xl border border-white/8 shadow-[0_8px_40px_rgba(0,0,0,0.4)]">
               <Image
                 src={project.imageUrl}
@@ -320,7 +316,7 @@ export default function ProjectDetailClient({
               {features.map((feat, i) => (
                 <motion.li
                   key={i}
-                  variants={fadeUp}
+                  variants={fadeMicro}
                   className="flex items-start gap-3 rounded-xl border border-white/8 bg-white/[0.02] p-4"
                 >
                   <span className="mt-0.5 flex h-5 w-5 shrink-0 items-center justify-center rounded-full bg-[#61DCA3]/20 text-xs text-[#61DCA3]">
@@ -339,7 +335,7 @@ export default function ProjectDetailClient({
             initial={reduceMotion ? false : "hidden"}
             whileInView="visible"
             viewport={{ once: true, margin: "-60px" }}
-            variants={fadeUp}
+            variants={fadeUpMajor}
             className="mb-16"
           >
             <div className="flex snap-x snap-mandatory gap-4 overflow-x-auto pb-4">
@@ -376,7 +372,7 @@ export default function ProjectDetailClient({
             initial={reduceMotion ? false : "hidden"}
             whileInView="visible"
             viewport={{ once: true, margin: "-60px" }}
-            variants={fadeUp}
+            variants={fadeUpMajor}
             className="mt-20 border-t border-white/8 pt-16"
           >
             <h2 className="mb-8 text-2xl font-extrabold text-white tracking-tight">
@@ -410,7 +406,7 @@ export default function ProjectDetailClient({
                   <Comp
                     key={rp.id}
                     {...linkProps}
-                    className="group rounded-2xl border border-white/8 bg-white/[0.02] p-5 transition hover:border-[#61DCA3]/30 hover:bg-white/[0.04]"
+                    className="group rounded-2xl border border-white/8 bg-white/[0.02] p-5 shadow-[0_4px_16px_rgba(0,0,0,0.12)] transition-all duration-300 hover:-translate-y-1 hover:border-[#61DCA3]/30 hover:bg-white/[0.04] hover:shadow-[0_12px_32px_rgba(97,220,163,0.08)]"
                   >
                     <div className="relative mb-4 h-32 w-full overflow-hidden rounded-xl">
                       <Image

--- a/app/projects/[slug]/ProjectDetailClient.tsx
+++ b/app/projects/[slug]/ProjectDetailClient.tsx
@@ -195,7 +195,7 @@ export default function ProjectDetailClient({
           className="mb-16"
         >
           {/* Badge row */}
-          <motion.div variants={fadeUpMajor} className="mb-4 flex flex-wrap items-center gap-3">
+          <motion.div variants={fadeMicro} className="mb-4 flex flex-wrap items-center gap-3">
             <span className="inline-flex items-center gap-1.5 rounded-full border border-[#61DCA3]/30 bg-[#61DCA3]/10 px-3 py-1 text-xs font-medium text-[#61DCA3]">
               {project.category === "mobile" ? (
                 <>
@@ -226,7 +226,7 @@ export default function ProjectDetailClient({
 
           {/* Meta row */}
           <motion.div
-            variants={fadeUpMajor}
+            variants={fadeMicro}
             className="mb-5 flex flex-wrap items-center gap-4 text-sm text-white/40"
           >
             {project.year && (
@@ -247,12 +247,12 @@ export default function ProjectDetailClient({
           </motion.div>
 
           {/* Tagline / short desc */}
-          <motion.p variants={fadeUpMajor} className="mb-6 max-w-2xl text-lg leading-relaxed text-white/60">
+          <motion.p variants={fadeMicro} className="mb-6 max-w-2xl text-lg leading-relaxed text-white/60">
             {descLocal(project, lang)}
           </motion.p>
 
           {/* CTA buttons */}
-          <motion.div variants={fadeUpMajor} className="mb-8 flex flex-wrap gap-3">
+          <motion.div variants={fadeMicro} className="mb-8 flex flex-wrap gap-3">
             {href && (
               <a
                 href={href}
@@ -276,7 +276,7 @@ export default function ProjectDetailClient({
           </motion.div>
 
           {/* Tech badges */}
-          <motion.div variants={fadeUpMajor} className="mb-8 flex flex-wrap gap-2">
+          <motion.div variants={fadeMicro} className="mb-8 flex flex-wrap gap-2">
             {techList.map((tech, i) => (
               <TechBadge key={`${project.id}-hero-t-${i}`} tech={tech} />
             ))}
@@ -375,7 +375,7 @@ export default function ProjectDetailClient({
             variants={fadeUpMajor}
             className="mt-20 border-t border-white/8 pt-16"
           >
-            <h2 className="mb-8 text-2xl font-extrabold text-white tracking-tight">
+            <h2 className="font-accent mb-8 text-2xl font-medium text-white tracking-tight">
               {t.related}
             </h2>
             <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">

--- a/lib/motion.ts
+++ b/lib/motion.ts
@@ -1,0 +1,30 @@
+import type { Variants } from "framer-motion";
+
+// This exact curve already existed, duplicated, in Contact.tsx,
+// Experience.tsx, and Footer.tsx as a local `easeOut` constant — it's a
+// deliberate, already-proven easing, just never centralized. Every other
+// section used Framer Motion's generic string "easeOut" instead, which is
+// a different (more linear-feeling) curve. Centralizing this one makes it
+// the site's single "major moment" curve, used everywhere a major moment
+// happens instead of silently varying by section.
+export const easeMajor = [0.16, 1, 0.3, 1] as const;
+
+// Major moments: hero entrance, section headings, page transitions.
+// Duration sits at the top of the spec's 0.6–0.8s range.
+export const fadeUpMajor: Variants = {
+  hidden: { opacity: 0, y: 32 },
+  visible: {
+    opacity: 1,
+    y: 0,
+    transition: { duration: 0.7, ease: easeMajor },
+  },
+};
+
+// Repeated small elements: project cards, stat tiles, feature list items,
+// experience rows — deliberately quiet. If everything moves the same
+// amount as the section heading, nothing reads as more important than
+// anything else.
+export const fadeMicro: Variants = {
+  hidden: { opacity: 0 },
+  visible: { opacity: 1, transition: { duration: 0.2 } },
+};


### PR DESCRIPTION
## Summary

Implements `docs/superpowers/specs/2026-07-27-ui-overhaul-design.md` via `docs/superpowers/plans/2026-07-30-ui-overhaul-implementation.md` — 14 tasks executed subagent-driven, each with an isolated implementer + independent reviewer, plus a final whole-branch review on the most capable model. Full execution ledger: `.superpowers/sdd/2026-07-30-ui-overhaul-implementation/progress.md` (gitignored, not part of this diff, but available in the worktree for reference).

**Foundation:**
- `app/globals.css`: new `--color-accent-warm` token + documented radius/spacing convention
- `lib/motion.ts` (new): `fadeUpMajor` (major moments) / `fadeMicro` (repeated small elements) — replaces near-duplicate `Variants` objects that were independently scattered across Contact.tsx, Experience.tsx, Footer.tsx, Hero.tsx, and others
- Fraunces serif accent font added alongside Poppins (narrowed from 6 to 4 weights: 400/500/600/800), applied via a `.font-accent` utility strictly to section headings + the hero name — never to nav links, buttons, badges, or form labels

**Per-section passes:** Hero, About (+ EN/ID stats bugfix), Skills, Project, Experience, Contact, Navbar/Footer, the project detail page, and the chatbot widget — applying the motion hierarchy, serif headings, and layered card-hover depth (translateY lift + growing shadow, replacing border-only hover swaps).

**Performance:** `Squares.tsx`'s background grid throttled to a third of its previous redraw rate (frame-skip + speed compensation, verified mathematically equivalent on-screen speed).

## Two real bugs caught and fixed mid-execution (not in the original plan)

1. **Font-weight cut broke existing bold text sitewide.** Cutting Poppins to 3 weights (400/600/800) left Tailwind's `font-bold` (700) unbacked across 11 locations — found via `grep`, fixed by swapping to `font-semibold`.
2. **The exact same category of bug recurred with `font-medium` (weight 500)** and was caught by the final whole-branch review (dispatched on the most capable model specifically to catch cross-task issues no single narrow review could see) — fixed by restoring weight 500 to the font loader rather than touching any of the 17+ call sites.

Both are now covered by a repeatable check: `grep -rE "font-(thin|light|normal|medium|semibold|bold|extrabold|black)" app --include="*.tsx" -o | sort | uniq -c`, cross-referenced against whatever weights `next/font/google` actually loads.

## Also fixed by the final whole-branch review
- `Footer.tsx` had one last inline duplicate of the easing curve `lib/motion.ts` was built to centralize — missed because Footer's own task only audited radius/spacing, not motion.
- One section heading (Related Projects, on the project detail page) was missed in the serif pass.
- The project detail page's hero block had over-applied the "major moment" treatment to 5 secondary elements (badge row, meta row, tagline, CTA row, tech-badges) that should read as quieter, matching the spec's own stated hierarchy.

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] `npm run build` succeeds (all static + SSG project-slug pages generate)
- [x] Spec's own grep-based verification: `.font-accent` appears only on headings/hero-name (zero leaks to functional UI); zero duplicate motion-preset constants remain anywhere; About stats match EN/ID (both 15)
- [x] Live browser check confirms Fraunces renders correctly (italic, correct family) and all class swaps apply as expected in the actual DOM
- [x] Contrast spot-check (canvas-composited, not naive parsing): hero tagline 9.57:1, card body 5.33:1 — both pass WCAG AA
- [x] Security: Contact.tsx honeypot + `sendEmail`'s `company` field confirmed byte-identical throughout, never touched
- [ ] Lighthouse accessibility comparison against the Fase 0 baseline — not run in this environment (no Lighthouse tool available here); recommend running manually via Chrome DevTools against the deployed preview before merging