### PR TITLE
fix: Lanyard scroll-pause + speed, Skills categorization, Project card motion

### DIFF
--- a/app/components/Lanyard/Lanyard.tsx
+++ b/app/components/Lanyard/Lanyard.tsx
@@ -59,6 +59,11 @@ interface LanyardProps {
   gravity?: [number, number, number];
   fov?: number;
   transparent?: boolean;
+  // While true, the R3F render loop (and the physics step it drives)
+  // stops entirely instead of just rendering less — a continuous
+  // WebGL + Rapier loop competes with the browser's scroll compositor
+  // for the same thread, which is what read as "scroll feels janky."
+  paused?: boolean;
 }
 
 export default function Lanyard({
@@ -66,6 +71,7 @@ export default function Lanyard({
   gravity = [0, -40, 0],
   fov = 20,
   transparent = true,
+  paused = false,
 }: LanyardProps) {
   return (
     <div className="relative z-0 flex h-full w-full items-center justify-center overflow-visible">
@@ -73,6 +79,7 @@ export default function Lanyard({
         camera={{ position, fov }}
         dpr={[1, 1.5]}
         gl={{ alpha: transparent }}
+        frameloop={paused ? "never" : "always"}
         style={{ width: "100%", height: "100%" }}
         onCreated={({ gl }) =>
           gl.setClearColor(new THREE.Color(0x000000), transparent ? 0 : 1)

--- a/app/components/sections/Hero.tsx
+++ b/app/components/sections/Hero.tsx
@@ -45,8 +45,11 @@ function useShouldMountLanyard() {
     };
 
     if (win.requestIdleCallback) {
+      // Timeout capped at 600ms (was 2000ms) — long enough to stay off
+      // the initial-load critical path, short enough that the card
+      // doesn't read as "stuck" on the poster before it's clearly idle.
       const handle = win.requestIdleCallback(() => setShouldMount(true), {
-        timeout: 2000,
+        timeout: 600,
       });
       return () => win.cancelIdleCallback?.(handle);
     }
@@ -59,9 +62,35 @@ function useShouldMountLanyard() {
   return shouldMount;
 }
 
+// Pauses the Lanyard's WebGL render loop (and the physics step it
+// drives) while the page is actively scrolling. A continuous R3F
+// frameloop competes with the browser's scroll compositor on the same
+// thread — pausing it during scroll bursts is what actually fixes
+// scroll feeling janky, not just lowering its overall draw frequency.
+function useIsScrolling() {
+  const [isScrolling, setIsScrolling] = useState(false);
+
+  useEffect(() => {
+    let timer: ReturnType<typeof setTimeout> | null = null;
+    const handleScroll = () => {
+      setIsScrolling(true);
+      if (timer) clearTimeout(timer);
+      timer = setTimeout(() => setIsScrolling(false), 150);
+    };
+    window.addEventListener("scroll", handleScroll, { passive: true });
+    return () => {
+      window.removeEventListener("scroll", handleScroll);
+      if (timer) clearTimeout(timer);
+    };
+  }, []);
+
+  return isScrolling;
+}
+
 export default function Hero() {
   const { t, lang } = useLanguage();
   const shouldMountLanyard = useShouldMountLanyard();
+  const isScrolling = useIsScrolling();
   const reduceMotion = useReducedMotion();
 
   return (
@@ -191,7 +220,7 @@ export default function Hero() {
               className="max-lg:relative max-lg:-mt-24 max-lg:h-[530px] max-lg:w-full max-lg:max-w-[470px] max-lg:overflow-hidden max-lg:pt-22 max-lg:sm:-mt-28 max-lg:sm:h-[620px] max-lg:sm:max-w-[560px] max-lg:sm:pt-20 max-lg:md:-mt-24 max-lg:md:h-[700px] max-lg:md:max-w-[660px] max-lg:md:pt-24 lg:h-full lg:w-full"
             >
               {shouldMountLanyard ? (
-                <Lanyard position={[0, 0, 15]} gravity={[0, -40, 0]} />
+                <Lanyard position={[0, 0, 15]} gravity={[0, -40, 0]} paused={isScrolling} />
               ) : (
                 <LanyardPoster />
               )}

--- a/app/components/sections/Project.tsx
+++ b/app/components/sections/Project.tsx
@@ -43,6 +43,20 @@ const projectGrid: Variants = {
   },
 };
 
+// Project cards are the actual showcase content, not a background
+// repeated element like a badge or stat tile — fadeMicro (opacity-only)
+// read as too static once seen live. A modest 12px rise plus a touch
+// more duration gives each card a sense of arriving, while staying well
+// short of fadeUpMajor's 32px/0.7s "big moment" treatment.
+const projectCardReveal: Variants = {
+  hidden: { opacity: 0, y: 12 },
+  visible: {
+    opacity: 1,
+    y: 0,
+    transition: { duration: 0.35 },
+  },
+};
+
 function TechBadge({ tech }: { tech: string }) {
   const meta = getTechMeta(tech);
   const label = getTechDisplayLabel(tech);
@@ -282,7 +296,7 @@ export default function Project({
               return (
                 <motion.div
                   key={project.id}
-                  variants={fadeMicro}
+                  variants={projectCardReveal}
                   className="flex justify-center"
                 >
                   <div className="group/card block h-[24rem] w-96 max-w-full [perspective:1000px]">

--- a/lib/tech-stack.tsx
+++ b/lib/tech-stack.tsx
@@ -175,8 +175,10 @@ export const featuredSkills = [
 
 export const techCategories = {
   Frontend: ["Next.js", "React", "TypeScript", "Tailwind CSS", "Framer Motion", "HTML5", "CSS3"],
-  Backend: ["Node.js", "Express.js", "NestJS", "Go", "Python", "PHP", "Laravel", "GraphQL", "REST API"],
-  Database: ["PostgreSQL", "MySQL", "MongoDB", "Redis", "Firebase", "Supabase", "Prisma", "Drizzle ORM"],
+  // Prisma and Drizzle ORM moved here from Database — they're ORMs (a
+  // backend data-access layer), not databases themselves.
+  Backend: ["Node.js", "Express.js", "NestJS", "Go", "Python", "PHP", "Laravel", "GraphQL", "REST API", "Prisma", "Drizzle ORM"],
+  Database: ["PostgreSQL", "MySQL", "MongoDB", "Redis", "Firebase", "Supabase"],
   "DevOps & Tools": ["Docker", "Linux", "Git", "GitHub", "Vercel", "Railway", "Cloudinary", "Figma"],
   Mobile: ["React Native", "Expo", "Kotlin", "Java"],
 } as const;


### PR DESCRIPTION
## Summary
Live feedback after Fase 6 deployed to preview: scrolling felt janky, Lanyard took too long to appear, Skills section felt too dense, and Project cards' entrance animation read as too static once seen live rather than in code review.

- **Lanyard pauses during active scroll.** Added a `paused` prop that sets the R3F Canvas's `frameloop` to `"never"` while scrolling (debounced, 150ms settle after the last scroll event), resuming automatically once scrolling stops. A continuous WebGL render loop + the Rapier physics step it drives is the only thing on this page running a comparable continuous main-thread loop — most likely root cause of "scroll terasa aneh."
- **Lanyard mount timeout cut from 2000ms → 600ms.** Still off the initial-load critical path (still gated behind `requestIdleCallback`), but no longer reads as stuck on the poster.
- **Prisma and Drizzle ORM recategorized.** They were listed under "Database" — a real accuracy bug (they're ORMs, a backend data-access layer, not databases). Moved to "Backend." No skills removed, just correctly placed.
- **Project cards get a real entrance instead of pure opacity fade.** They used the shared `fadeMicro` (appropriate for badges/stat tiles), which read as too static for the actual showcase content. Added a scoped `projectCardReveal` variant (12px rise, 0.35s) local to `Project.tsx` — doesn't touch `fadeMicro` itself, so other sections that correctly use it as a background element are unaffected. Skeleton loading cards keep `fadeMicro` since they're placeholders, not real content arriving.

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] `npm run build` succeeds
- [x] Live check: Lanyard mounts, Fraunces renders correctly, no console errors on scroll
- [x] Live check: Prisma/Drizzle ORM confirmed present in DOM under their new category