### PR TITLE
fix: Lanyard scroll-pause, About stats bug, Skills showcase audit

### DIFF
--- a/app/components/Lanyard/Lanyard.tsx
+++ b/app/components/Lanyard/Lanyard.tsx
@@ -59,6 +59,11 @@ interface LanyardProps {
   gravity?: [number, number, number];
   fov?: number;
   transparent?: boolean;
+  // While true, the R3F render loop (and the physics step it drives)
+  // stops entirely instead of just rendering less — a continuous
+  // WebGL + Rapier loop competes with the browser's scroll compositor
+  // for the same thread, which is what read as "scroll feels janky."
+  paused?: boolean;
 }
 
 export default function Lanyard({
@@ -66,6 +71,7 @@ export default function Lanyard({
   gravity = [0, -40, 0],
   fov = 20,
   transparent = true,
+  paused = false,
 }: LanyardProps) {
   return (
     <div className="relative z-0 flex h-full w-full items-center justify-center overflow-visible">
@@ -73,6 +79,7 @@ export default function Lanyard({
         camera={{ position, fov }}
         dpr={[1, 1.5]}
         gl={{ alpha: transparent }}
+        frameloop={paused ? "never" : "always"}
         style={{ width: "100%", height: "100%" }}
         onCreated={({ gl }) =>
           gl.setClearColor(new THREE.Color(0x000000), transparent ? 0 : 1)

--- a/app/components/sections/About.tsx
+++ b/app/components/sections/About.tsx
@@ -125,11 +125,16 @@ export default function About() {
 
         {/* Highlight cards */}
         <motion.div className="mb-16 grid gap-5 md:grid-cols-2" variants={container}>
-          {data.highlights.map((highlight) => {
+          {data.highlights.map((highlight, i) => {
             const Icon = highlight.icon;
             return (
               <motion.div
-                key={highlight.title}
+                // Index, not highlight.title — same class of bug as the
+                // stats row below: these titles happen to be identical
+                // in EN/ID right now, but keying on translated text is
+                // fragile the moment that changes. Array order is
+                // stable across languages.
+                key={i}
                 className="group rounded-2xl border border-white/8 bg-white/[0.03]
                            p-6 shadow-[0_4px_16px_rgba(0,0,0,0.15)]
                            transition-all duration-300
@@ -158,7 +163,16 @@ export default function About() {
         >
           {data.stats.map((stat, i) => (
             <motion.div
-              key={stat.label}
+              // Index, not stat.label — the label text differs between
+              // EN/ID for 2 of 3 stats ("Journals in Production" vs
+              // "Jurnal di Production"), so keying on it caused React to
+              // unmount+remount on every language switch. The remounted
+              // element then rendered at its animation's hidden state
+              // and never got told to animate in, since the parent's
+              // whileInView already fired once (once: true) — the stat
+              // was stuck invisible. The array order is stable across
+              // languages, so the index is a safe, stable identity here.
+              key={i}
               className={`flex flex-col items-center justify-center py-8 px-4
                           bg-white/[0.02] hover:bg-[#61DCA3]/5 transition-colors duration-300
                           ${i < data.stats.length - 1 ? "border-r border-white/8 last:border-r-0" : ""}`}

--- a/app/components/sections/Hero.tsx
+++ b/app/components/sections/Hero.tsx
@@ -45,8 +45,11 @@ function useShouldMountLanyard() {
     };
 
     if (win.requestIdleCallback) {
+      // Timeout capped at 600ms (was 2000ms) — long enough to stay off
+      // the initial-load critical path, short enough that the card
+      // doesn't read as "stuck" on the poster before it's clearly idle.
       const handle = win.requestIdleCallback(() => setShouldMount(true), {
-        timeout: 2000,
+        timeout: 600,
       });
       return () => win.cancelIdleCallback?.(handle);
     }
@@ -59,9 +62,35 @@ function useShouldMountLanyard() {
   return shouldMount;
 }
 
+// Pauses the Lanyard's WebGL render loop (and the physics step it
+// drives) while the page is actively scrolling. A continuous R3F
+// frameloop competes with the browser's scroll compositor on the same
+// thread — pausing it during scroll bursts is what actually fixes
+// scroll feeling janky, not just lowering its overall draw frequency.
+function useIsScrolling() {
+  const [isScrolling, setIsScrolling] = useState(false);
+
+  useEffect(() => {
+    let timer: ReturnType<typeof setTimeout> | null = null;
+    const handleScroll = () => {
+      setIsScrolling(true);
+      if (timer) clearTimeout(timer);
+      timer = setTimeout(() => setIsScrolling(false), 150);
+    };
+    window.addEventListener("scroll", handleScroll, { passive: true });
+    return () => {
+      window.removeEventListener("scroll", handleScroll);
+      if (timer) clearTimeout(timer);
+    };
+  }, []);
+
+  return isScrolling;
+}
+
 export default function Hero() {
   const { t, lang } = useLanguage();
   const shouldMountLanyard = useShouldMountLanyard();
+  const isScrolling = useIsScrolling();
   const reduceMotion = useReducedMotion();
 
   return (
@@ -191,7 +220,7 @@ export default function Hero() {
               className="max-lg:relative max-lg:-mt-24 max-lg:h-[530px] max-lg:w-full max-lg:max-w-[470px] max-lg:overflow-hidden max-lg:pt-22 max-lg:sm:-mt-28 max-lg:sm:h-[620px] max-lg:sm:max-w-[560px] max-lg:sm:pt-20 max-lg:md:-mt-24 max-lg:md:h-[700px] max-lg:md:max-w-[660px] max-lg:md:pt-24 lg:h-full lg:w-full"
             >
               {shouldMountLanyard ? (
-                <Lanyard position={[0, 0, 15]} gravity={[0, -40, 0]} />
+                <Lanyard position={[0, 0, 15]} gravity={[0, -40, 0]} paused={isScrolling} />
               ) : (
                 <LanyardPoster />
               )}

--- a/app/components/sections/Project.tsx
+++ b/app/components/sections/Project.tsx
@@ -43,6 +43,20 @@ const projectGrid: Variants = {
   },
 };
 
+// Project cards are the actual showcase content, not a background
+// repeated element like a badge or stat tile — fadeMicro (opacity-only)
+// read as too static once seen live. A modest 12px rise plus a touch
+// more duration gives each card a sense of arriving, while staying well
+// short of fadeUpMajor's 32px/0.7s "big moment" treatment.
+const projectCardReveal: Variants = {
+  hidden: { opacity: 0, y: 12 },
+  visible: {
+    opacity: 1,
+    y: 0,
+    transition: { duration: 0.35 },
+  },
+};
+
 function TechBadge({ tech }: { tech: string }) {
   const meta = getTechMeta(tech);
   const label = getTechDisplayLabel(tech);
@@ -282,7 +296,7 @@ export default function Project({
               return (
                 <motion.div
                   key={project.id}
-                  variants={fadeMicro}
+                  variants={projectCardReveal}
                   className="flex justify-center"
                 >
                   <div className="group/card block h-[24rem] w-96 max-w-full [perspective:1000px]">

--- a/lib/tech-stack.tsx
+++ b/lib/tech-stack.tsx
@@ -175,8 +175,10 @@ export const featuredSkills = [
 
 export const techCategories = {
   Frontend: ["Next.js", "React", "TypeScript", "Tailwind CSS", "Framer Motion", "HTML5", "CSS3"],
-  Backend: ["Node.js", "Express.js", "NestJS", "Go", "Python", "PHP", "Laravel", "GraphQL", "REST API"],
-  Database: ["PostgreSQL", "MySQL", "MongoDB", "Redis", "Firebase", "Supabase", "Prisma", "Drizzle ORM"],
+  // Prisma and Drizzle ORM moved here from Database — they're ORMs (a
+  // backend data-access layer), not databases themselves.
+  Backend: ["Node.js", "Express.js", "NestJS", "Go", "Python", "PHP", "Laravel", "GraphQL", "REST API", "Prisma", "Drizzle ORM"],
+  Database: ["PostgreSQL", "MySQL", "MongoDB", "Redis", "Firebase", "Supabase"],
   "DevOps & Tools": ["Docker", "Linux", "Git", "GitHub", "Vercel", "Railway", "Cloudinary", "Figma"],
   Mobile: ["React Native", "Expo", "Kotlin", "Java"],
 } as const;

--- a/lib/tech-stack.tsx
+++ b/lib/tech-stack.tsx
@@ -173,8 +173,15 @@ export const featuredSkills = [
   "PostgreSQL", "Drizzle ORM", "Firebase", "Supabase", "Docker", "Vercel", "GitHub", "Figma", "Linux",
 ].map((s) => getTechMeta(s) ?? { label: s });
 
+// This list is the Skills-section showcase only — not the full catalog
+// (see techCatalog above, still used for per-project tech badges).
+// HTML5/CSS3 dropped: React/Next.js/Tailwind CSS already necessarily
+// demonstrate them, so listing them separately reads as too basic for
+// this level. They still work fine as a per-project tech badge if a
+// specific project's own tech list names them (e.g. a plain HTML/CSS
+// project with no framework) — only removed from this general showcase.
 export const techCategories = {
-  Frontend: ["Next.js", "React", "TypeScript", "Tailwind CSS", "Framer Motion", "HTML5", "CSS3"],
+  Frontend: ["Next.js", "React", "TypeScript", "Tailwind CSS", "Framer Motion"],
   // Prisma and Drizzle ORM moved here from Database — they're ORMs (a
   // backend data-access layer), not databases themselves.
   Backend: ["Node.js", "Express.js", "NestJS", "Go", "Python", "PHP", "Laravel", "GraphQL", "REST API", "Prisma", "Drizzle ORM"],

--- a/lib/tech-stack.tsx
+++ b/lib/tech-stack.tsx
@@ -181,11 +181,23 @@ export const featuredSkills = [
 // specific project's own tech list names them (e.g. a plain HTML/CSS
 // project with no framework) — only removed from this general showcase.
 export const techCategories = {
-  Frontend: ["Next.js", "React", "TypeScript", "Tailwind CSS", "Framer Motion"],
+  // TensorFlow and face-api.js added — both genuinely shipped (Presence's
+  // face-recognition + liveness detection), and more distinctive than
+  // generic frontend entries.
+  Frontend: ["Next.js", "React", "TypeScript", "Tailwind CSS", "Framer Motion", "TensorFlow", "face-api.js"],
   // Prisma and Drizzle ORM moved here from Database — they're ORMs (a
   // backend data-access layer), not databases themselves.
-  Backend: ["Node.js", "Express.js", "NestJS", "Go", "Python", "PHP", "Laravel", "GraphQL", "REST API", "Prisma", "Drizzle ORM"],
-  Database: ["PostgreSQL", "MySQL", "MongoDB", "Redis", "Firebase", "Supabase"],
+  // NestJS, Go, and GraphQL removed — no shipped project or knowledge-base
+  // claim backs them; re-add once an actual project uses one.
+  // Groq AI added — powers this site's own chatbot and LacakKarirku's
+  // CV/job matching, both real shipped usage.
+  Backend: ["Node.js", "Express.js", "Python", "PHP", "Laravel", "REST API", "Prisma", "Drizzle ORM", "Groq AI"],
+  // Redis removed (no shipped project or knowledge-base claim). MongoDB
+  // and Linux kept per explicit confirmation — genuinely known, just not
+  // yet reflected in a shipped project.
+  // pgvector added — the vector-similarity search behind Presence's
+  // face-matching, a genuinely distinctive database skill.
+  Database: ["PostgreSQL", "MySQL", "MongoDB", "Firebase", "Supabase", "pgvector"],
   "DevOps & Tools": ["Docker", "Linux", "Git", "GitHub", "Vercel", "Railway", "Cloudinary", "Figma"],
   Mobile: ["React Native", "Expo", "Kotlin", "Java"],
 } as const;


### PR DESCRIPTION
## Summary
Live feedback fixes after Fase 6 deployed, plus one real bug found from actual browser use.

**Performance/UX:**
- Lanyard's R3F Canvas now pauses its render loop (`frameloop: "never"`) during active scroll (debounced, 150ms settle) — a continuous WebGL + Rapier physics loop was competing with the browser's scroll compositor, the likely cause of "scroll terasa aneh."
- Lanyard's idle-mount timeout cut from 2000ms to 600ms — still off the initial-load critical path, no longer reads as stuck on the poster.

**Real bug — About section stats disappearing on language switch:**
Two of three stat entries were keyed by their label text (`key={stat.label}`). Switching language changes that text for 2 of 3 stats, so React unmounted+remounted those elements instead of updating them. The remounted element rendered at its motion variant's hidden state and never got animated in, because the parent's `whileInView` had already fired once (`{ once: true }`) on first scroll into view. Fixed by switching to index-based keys (stable across language switches) — also fixed the same latent pattern in the highlight cards before it could trigger.

**Skills showcase content audit** (cross-referenced against all 15 shipped projects' actual tech lists + the chatbot knowledge base):
- Removed HTML5/CSS3 from the showcase (still work as per-project tech badges) — redundant once React/Next.js/Tailwind are listed
- Removed NestJS, Go, GraphQL, Redis — zero evidence in any shipped project or the knowledge base
- Kept MongoDB, Linux per explicit confirmation (real skills, just not yet in a shipped project)
- Added TensorFlow, face-api.js, Groq AI, pgvector — genuinely shipped (Presence's face-recognition, this site's own chatbot, LacakKarirku's job matching) and more distinctive than what was removed
- Fixed Prisma/Drizzle ORM miscategorized under "Database" (they're ORMs, not databases) — moved to Backend

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] `npm run build` succeeds
- [x] Root-cause verified by reading React reconciliation + Framer Motion variant-propagation behavior (live browser confirmation was limited by this environment's rendering pane; recommend the user verify the language-switch fix themselves once deployed)